### PR TITLE
Eliminar automáticamente vídeos de más de 30 minutos de la base de da…

### DIFF
--- a/backend/src/main/java/com/nocountry/videoconverter/VideoConverterApiApplication.java
+++ b/backend/src/main/java/com/nocountry/videoconverter/VideoConverterApiApplication.java
@@ -3,10 +3,11 @@ package com.nocountry.videoconverter;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
-
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAsync
+@EnableScheduling
 public class VideoConverterApiApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/nocountry/videoconverter/repositories/ConversionJobRepository.java
+++ b/backend/src/main/java/com/nocountry/videoconverter/repositories/ConversionJobRepository.java
@@ -1,7 +1,15 @@
 package com.nocountry.videoconverter.repositories;
 
 import com.nocountry.videoconverter.entities.ConversionJob;
+import com.nocountry.videoconverter.entities.JobStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface ConversionJobRepository extends JpaRepository<ConversionJob, String> {
+    List<ConversionJob> findByCreatedAtBefore(LocalDateTime cutoff);
+
+    List<ConversionJob> findByCreatedAtBeforeAndStatusNot(LocalDateTime cutoff, JobStatus status);
 }

--- a/backend/src/main/java/com/nocountry/videoconverter/services/VideoCleanupScheduler.java
+++ b/backend/src/main/java/com/nocountry/videoconverter/services/VideoCleanupScheduler.java
@@ -1,0 +1,38 @@
+package com.nocountry.videoconverter.services;
+
+import com.nocountry.videoconverter.entities.ConversionJob;
+import com.nocountry.videoconverter.entities.JobStatus;
+import com.nocountry.videoconverter.repositories.ConversionJobRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class VideoCleanupScheduler {
+
+    private final ConversionJobRepository conversionJobRepository;
+    private final VideoStorageService videoStorageService;
+
+    // Corre cada 60s (Se puede ajustar)
+    @Scheduled(fixedDelay = 60_000)
+    @Transactional
+    public void deleteOldVideos() {
+        LocalDateTime cutoff = LocalDateTime.now().minusMinutes(30);
+
+        // Evita borrar jobs que estén procesándose (por seguridad)
+        List<ConversionJob> oldJobs =
+                conversionJobRepository.findByCreatedAtBeforeAndStatusNot(cutoff, JobStatus.PROCESSING);
+
+        for (ConversionJob job : oldJobs) {
+            videoStorageService.delete(job.getInputUrl());
+            videoStorageService.delete(job.getOutputUrl());
+
+            conversionJobRepository.delete(job);
+        }
+    }
+}

--- a/backend/src/main/java/com/nocountry/videoconverter/services/VideoStorageService.java
+++ b/backend/src/main/java/com/nocountry/videoconverter/services/VideoStorageService.java
@@ -3,10 +3,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class VideoStorageService {
    // como aun los videos no se almacenan en algun repo los guardo en esta carpeta local 
     private final String UPLOAD_DIR = "videos/";
@@ -17,5 +20,17 @@ public class VideoStorageService {
         Files.createDirectories(filePath.getParent());
         Files.write(filePath, file.getBytes());
         return filePath.toString();
+    }
+
+    public boolean delete(String pathStr) {
+        if (pathStr == null || pathStr.isBlank()) return false;
+        try {
+            Path path = Paths.get(pathStr);
+            return Files.deleteIfExists(path);
+        } catch (IOException ex) {
+            // evitar lanzar excepción desde el scheduler; se puede loggear aquí
+            System.err.println("Error eliminando archivo: " + pathStr + " -> " + ex.getMessage());
+            return false;
+        }
     }
 }


### PR DESCRIPTION
…tos y el almacenamiento

- Agregar una tarea de limpieza programada para eliminar trabajos de conversión antiguos.
- Eliminar archivos de entrada/salida del almacenamiento local antes de eliminar registros de la base de datos.
- Habilitar la scheduling.