### PR TITLE
style: ajusta márgenes, tamaños y espaciado en componentes para mejor…

### DIFF
--- a/frontend/videoflow/app/components/bottomSection/BottomSection.tsx
+++ b/frontend/videoflow/app/components/bottomSection/BottomSection.tsx
@@ -4,7 +4,7 @@ import PrimaryButton from "../PrimaryButton/PrimaryButton";
 
 export default function BottomSection() {
     return (
-        <section className="bg-[#DEDCFF] mt-[80px] mb-[80px]">
+        <section className="bg-[#DEDCFF] mt-[80px] mb-[80px] ">
             {/* Layout móvil: < 768px */}
 
             <div className="mx-[50px] md:mx-[100px] lg:mx-[187px] xl:mx-[187px] 2xl:mx-[350px] md:hidden py-[60.5px] md:py-[80px] md:max-w-125.5 lg:max-w-125.5 xl:max-w-125.5 2xl:max-w-125.5 ">
@@ -33,28 +33,28 @@ export default function BottomSection() {
             </div>
             
             {/* Layout tablet/desktop: >= 768px */}
-            <div className="hidden md:grid grid-cols-2 gap-6 items-center mx-[50px] md:mx-[100px] lg:mx-[187px] xl:mx-[350px] py-8 md:py-10 lg:py-[60px]">
-    <div className="space-y-3 md:space-y-4 lg:space-y-5">
-        <h2 className="text-2xl md:text-3xl lg:text-[65px] font-bold text-black leading-tight">
+            <div className="hidden md:grid grid-cols-2 gap-6 lg:gap-8 xl:gap-10 2xl:gap-12 items-center mx-[50px] md:mx-[100px] lg:mx-[187px] xl:mx-[187px] 2xl:mx-[350px] py-8 md:py-10 lg:py-[60px]">
+    <div className="space-y-3 md:space-y-4 lg:space-y-4 xl:space-y-5 2xl:space-y-6">
+
+        <h2 className="text-[20px] md:text-[26px] lg:text-[32px] xl:text-[38px] 2xl:text-[48px] font-bold text-black leading-tight">
             Listo para crear tu primer short?
         </h2>
-        <p className="text-sm md:text-base lg:text-[27px] text-black leading-relaxed">
+        <p className="text-[14px] md:text-[16px] lg:text-[17px] xl:text-[18px] 2xl:text-[20px] text-black leading-relaxed">
             Subí tu video y empezá a reutilizar
             tu contenido en minutos.
         </p>
         <PrimaryButton />
     </div>
-    <div className="flex justify-end">
+    <div className="flex justify-end items-start">
         <Image
             src="/short.jpg"
             alt="Vista previa de video"
             width={502}
-            height={322}
-            className="w-full h-auto rounded-[10px] shadow-lg object-cover"
+            height={326}
+            className="w-auto h-auto md:w-[280px] lg:w-[320px] xl:w-[380px] 2xl:w-[450px] rounded-[10px] shadow-lg object-cover"
         />
     </div>
 </div>
-            
             
         </section>
     );

--- a/frontend/videoflow/app/components/card/card.tsx
+++ b/frontend/videoflow/app/components/card/card.tsx
@@ -1,66 +1,63 @@
 import { Clock, Send } from "lucide-react";
 export default function Card() {
     return (
-        <section className="mx-[50px] md:mx-[100px] lg:mx-[187px] xl:mx-[187px] 2xl:mx-[350px] mt-[60px]">
+        <section className="mx-[50px] md:mx-[100px] lg:mx-[187px] xl:mx-[187px] 2xl:mx-[350px] mt-[80px]">
 
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-[37px] md:gap-[37px] lg:gap-[80px] xl:gap-[150px] max-w-7xl mx-auto">
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-[37px] md:gap-[37px] lg:gap-[24px] xl:gap-[80px] 2xl:gap-[40px] max-w-7xl mx-auto">
 
         <article className="group bg-white rounded-2xl border border-gray-200 shadow-sm
-            p-6 md:p-4 lg:p-10
+            p-6 md:p-4 lg:p-6 xl:p-10 2xl:p-8
             text-center transition-all duration-700 delay-300
-            hover:translate-y-2 hover:shadow-[0_4px_6px_-2px_rgba(92,66,184,0.5)] hover:bg-[#DEDCFF] 
-            ">
+            hover:translate-y-2 hover:shadow-[0_4px_6px_-2px_rgba(92,66,184,0.5)] hover:bg-[#DEDCFF]">
 
-            <div className="mx-auto w-14 h-14 md:w-11 md:h-11 lg:w-22 lg:h-22 rounded-full bg-[#E7ECFC] group-hover:bg-[#5e58d4] flex items-center justify-center transition-all duration-700 delay-300 shadow-[0_6px_14px_rgba(165,160,255,0.35)]">
-                <div className="w-10 h-10 md:w-8 md:h-8 lg:w-16 lg:h-16 rounded-full bg-[#CDD8FB] group-hover:bg-white transition-all duration-700 delay-300 shadow-[0_6px_14px_rgba(165,160,255,0.35)] flex items-center justify-center">
-                    <img src="/iconcard1.svg" alt="" className="w-5 h-5 md:w-4 md:h-4 lg:w-[36px] lg:h-[36px]" />
+            <div className="mx-auto w-14 h-14 md:w-11 md:h-11 lg:w-14 lg:h-14 xl:w-22 xl:h-22 2xl:w-16 2xl:h-16 rounded-full bg-[#E7ECFC] group-hover:bg-[#5e58d4] flex items-center justify-center transition-all duration-700 delay-300 shadow-[0_6px_14px_rgba(165,160,255,0.35)]">
+                <div className="w-10 h-10 md:w-8 md:h-8 lg:w-10 lg:h-10 xl:w-16 xl:h-16 2xl:w-12 2xl:h-12 rounded-full bg-[#CDD8FB] group-hover:bg-white transition-all duration-700 delay-300 shadow-[0_6px_14px_rgba(165,160,255,0.35)] flex items-center justify-center">
+                    <img src="/iconcard1.svg" alt="" className="w-5 h-5 md:w-4 md:h-4 lg:w-5 lg:h-5 xl:w-[36px] xl:h-[36px] 2xl:w-[28px] 2xl:h-[28px]" />
                 </div>
             </div>
 
-            <h3 className="mt-4 md:mt-3 lg:mt-6 text-[21px] md:text-[15px] lg:text-[21px] font-bold text-gray-900">
+            <h3 className="mt-4 md:mt-3 lg:mt-4 xl:mt-6 2xl:mt-4 text-[21px] md:text-[15px] lg:text-[16px] xl:text-[21px] 2xl:text-[18px] font-bold text-gray-900">
                 Rápido
             </h3>
-            <p className="mt-2 text-[16px] md:text-[12px] lg:text-base text-gray-700 leading-relaxed">
+            <p className="mt-2 text-[16px] md:text-[12px] lg:text-[13px] xl:text-base 2xl:text-[14px] text-gray-700 leading-relaxed">
                 Convertí videos en segundos, no en horas. Sin necesidad de edición compleja.
             </p>
         </article>
 
         <article className="group bg-white rounded-2xl border border-gray-200 shadow-sm
-            p-6 md:p-4 lg:p-10
+            p-6 md:p-4 lg:p-6 xl:p-10 2xl:p-8
             text-center transition-all duration-700 delay-300
-            hover:translate-y-2 hover:shadow-[0_4px_6px_-2px_rgba(92,66,184,0.5)] hover:bg-[#DEDCFF]
-            ">
+            hover:translate-y-2 hover:shadow-[0_4px_6px_-2px_rgba(92,66,184,0.5)] hover:bg-[#DEDCFF]">
 
-            <div className="mx-auto w-14 h-14 md:w-11 md:h-11 lg:w-22 lg:h-22 rounded-full bg-[#E7ECFC] group-hover:bg-[#5e58d4] flex items-center justify-center transition-all duration-700 delay-300 shadow-[0_6px_14px_rgba(165,160,255,0.35)]">
-                <div className="w-10 h-10 md:w-8 md:h-8 lg:w-16 lg:h-16 rounded-full bg-[#CDD8FB] group-hover:bg-white transition-all duration-700 delay-300 shadow-[0_6px_14px_rgba(165,160,255,0.35)] flex items-center justify-center">
-                    <img src="/iconcard2.svg" alt="" className="w-5 h-5 md:w-4 md:h-4 lg:w-[36px] lg:h-[36px]" />
+            <div className="mx-auto w-14 h-14 md:w-11 md:h-11 lg:w-14 lg:h-14 xl:w-22 xl:h-22 2xl:w-16 2xl:h-16 rounded-full bg-[#E7ECFC] group-hover:bg-[#5e58d4] flex items-center justify-center transition-all duration-700 delay-300 shadow-[0_6px_14px_rgba(165,160,255,0.35)]">
+                <div className="w-10 h-10 md:w-8 md:h-8 lg:w-10 lg:h-10 xl:w-16 xl:h-16 2xl:w-12 2xl:h-12 rounded-full bg-[#CDD8FB] group-hover:bg-white transition-all duration-700 delay-300 shadow-[0_6px_14px_rgba(165,160,255,0.35)] flex items-center justify-center">
+                    <img src="/iconcard2.svg" alt="" className="w-5 h-5 md:w-4 md:h-4 lg:w-5 lg:h-5 xl:w-[36px] xl:h-[36px] 2xl:w-[28px] 2xl:h-[28px]" />
                 </div>
             </div>
 
-            <h3 className="mt-4 md:mt-3 lg:mt-6 text-[21px] md:text-[15px] lg:text-[21px] font-bold text-gray-900">
+            <h3 className="mt-4 md:mt-3 lg:mt-4 xl:mt-6 2xl:mt-4 text-[21px] md:text-[15px] lg:text-[16px] xl:text-[21px] 2xl:text-[18px] font-bold text-gray-900">
                 Ahorra tiempo
             </h3>
-            <p className="mt-2 text-[16px] md:text-[12px] lg:text-base text-gray-700 leading-relaxed">
+            <p className="mt-2 text-[16px] md:text-[12px] lg:text-[13px] xl:text-base 2xl:text-[14px] text-gray-700 leading-relaxed">
                 Concentrate en tu negocio mientras nosotros nos encargamos de la conversión de video.
             </p>
         </article>
 
         <article className="group bg-white rounded-2xl border border-gray-200 shadow-sm
-            p-6 md:p-4 lg:p-10
+            p-6 md:p-4 lg:p-6 xl:p-10 2xl:p-8
             text-center transition-all duration-700 delay-300
-            hover:translate-y-2 hover:shadow-[0_4px_6px_-2px_rgba(92,66,184,0.5)] hover:bg-[#DEDCFF]
-            ">
+            hover:translate-y-2 hover:shadow-[0_4px_6px_-2px_rgba(92,66,184,0.5)] hover:bg-[#DEDCFF]">
 
-            <div className="mx-auto w-14 h-14 md:w-11 md:h-11 lg:w-22 lg:h-22 rounded-full bg-[#E7ECFC] group-hover:bg-[#5e58d4] flex items-center justify-center transition-all duration-700 delay-300 shadow-[0_6px_14px_rgba(165,160,255,0.35)]">
-                <div className="w-10 h-10 md:w-8 md:h-8 lg:w-16 lg:h-16 rounded-full bg-[#CDD8FB] group-hover:bg-white transition-all duration-700 delay-300 shadow-[0_6px_14px_rgba(165,160,255,0.35)] flex items-center justify-center">
-                    <img src="/iconcard3.svg" alt="" className="w-5 h-5 md:w-4 md:h-4 lg:w-[36px] lg:h-[36px]" />
+            <div className="mx-auto w-14 h-14 md:w-11 md:h-11 lg:w-14 lg:h-14 xl:w-22 xl:h-22 2xl:w-16 2xl:h-16 rounded-full bg-[#E7ECFC] group-hover:bg-[#5e58d4] flex items-center justify-center transition-all duration-700 delay-300 shadow-[0_6px_14px_rgba(165,160,255,0.35)]">
+                <div className="w-10 h-10 md:w-8 md:h-8 lg:w-10 lg:h-10 xl:w-16 xl:h-16 2xl:w-12 2xl:h-12 rounded-full bg-[#CDD8FB] group-hover:bg-white transition-all duration-700 delay-300 shadow-[0_6px_14px_rgba(165,160,255,0.35)] flex items-center justify-center">
+                    <img src="/iconcard3.svg" alt="" className="w-5 h-5 md:w-4 md:h-4 lg:w-5 lg:h-5 xl:w-[36px] xl:h-[36px] 2xl:w-[28px] 2xl:h-[28px]" />
                 </div>
             </div>
 
-            <h3 className="mt-4 md:mt-3 lg:mt-6 text-[21px] md:text-[15px] lg:text-[21px] font-bold text-gray-900">
+            <h3 className="mt-4 md:mt-3 lg:mt-4 xl:mt-6 2xl:mt-4 text-[21px] md:text-[15px] lg:text-[16px] xl:text-[21px] 2xl:text-[18px] font-bold text-gray-900">
                 Listo para publicar
             </h3>
-            <p className="mt-2 text-[16px] md:text-[12px] lg:text-base text-gray-700 leading-relaxed">
+            <p className="mt-2 text-[16px] md:text-[12px] lg:text-[13px] xl:text-base 2xl:text-[14px] text-gray-700 leading-relaxed">
                 Exportá en el formato perfecto para todas las principales plataformas sociales.
             </p>
         </article>


### PR DESCRIPTION
### Se ajusta márgenes, tamaños y espaciado en componentes para mejorar la presentación y responsividad

### iPad-Air-5-1320x2282
<img width="1320" height="2282" alt="iPad-Air-5-1320x2282" src="https://github.com/user-attachments/assets/d76c8850-c7d9-45e9-a860-2bc39c387fac" />

### iPhone-14-Pro-2068x3300
<img width="2068" height="3300" alt="iPhone-14-Pro-2068x3300" src="https://github.com/user-attachments/assets/92c88a3c-6dd4-447a-b922-05c24d0ce705" />

### iPhone-14-Pro-Max-2136x3134
<img width="2136" height="3134" alt="iPhone-14-Pro-Max-2136x3134" src="https://github.com/user-attachments/assets/46f1e574-05e5-4fa4-9989-bb0d4f399f97" />

### Macbook-Air-1559x2407
<img width="1559" height="2407" alt="Macbook-Air-1559x2407" src="https://github.com/user-attachments/assets/673506a3-8e1f-422a-9c6d-31ee709a3c3c" />

### Pixel-7-Pro-2412x1994
<img width="2412" height="1994" alt="Pixel-7-Pro-2412x1994" src="https://github.com/user-attachments/assets/45d22e1c-4232-4ed0-ae11-484e7e56a65a" />
